### PR TITLE
Fixed app component Input.js. Added webpack resolve project path

### DIFF
--- a/resources/assets/js/app/App.js
+++ b/resources/assets/js/app/App.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
 
-import MainHeader from './components/MainHeader';
+import MainHeader from 'app/components/MainHeader';
 
-import './bootstrap/bootstrap.scss';
-import './styles/app.scss';
+import 'app/bootstrap/bootstrap.scss';
+import 'app/styles/app.scss';
 
 class App extends Component {
 

--- a/resources/assets/js/app/components/Input.js
+++ b/resources/assets/js/app/components/Input.js
@@ -1,6 +1,6 @@
-import React from 'React';
+import React, { Component } from 'react';
 
-class Input extends React.Component {
+class Input extends Component {
     render() {
         return (
             <div className={"form-group row " + (this.props.error ? 'has-danger' : '')} >

--- a/resources/assets/js/app/layouts/Home.js
+++ b/resources/assets/js/app/layouts/Home.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 
-import PageHeader from '../components/PageHeader';
+import PageHeader from 'app/components/PageHeader';
 
 class Home extends Component {
 

--- a/resources/assets/js/app/layouts/NotFound.js
+++ b/resources/assets/js/app/layouts/NotFound.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router';
 
-import PageHeader from '../components/PageHeader';
+import PageHeader from 'app/components/PageHeader';
 
 class NotFound extends Component {
 

--- a/resources/assets/js/app/reducer.js
+++ b/resources/assets/js/app/reducer.js
@@ -1,7 +1,7 @@
 import { combineReducers } from 'redux';
 
-import vehicle from '../features/vehicle/reducer';
-import user from '../features/user/reducer';
+import vehicle from 'features/vehicle/reducer';
+import user from 'features/user/reducer';
 
 export default combineReducers({
     vehicle,

--- a/resources/assets/js/app/routes.js
+++ b/resources/assets/js/app/routes.js
@@ -1,14 +1,14 @@
 import React from 'react';
 import { IndexRoute, Route, Redirect } from 'react-router';
 
-import App from './App';
-import Home from './layouts/Home';
-import Vehicles from '../features/vehicle/layouts/Vehicles';
-import VehicleDetails from '../features/vehicle/layouts/VehicleDetails';
-import NotFound from './layouts/NotFound';
-import RegisterForm from '../features/user/layouts/RegisterForm';
-import RegisterSuccess from '../features/user/layouts/RegisterSuccess';
-import RegisterVerify from '../features/user/layouts/RegisterVerify';
+import App from 'app/App';
+import Home from 'app/layouts/Home';
+import Vehicles from 'features/vehicle/layouts/Vehicles';
+import VehicleDetails from 'features/vehicle/layouts/VehicleDetails';
+import NotFound from 'app/layouts/NotFound';
+import RegisterForm from 'features/user/layouts/RegisterForm';
+import RegisterSuccess from 'features/user/layouts/RegisterSuccess';
+import RegisterVerify from 'features/user/layouts/RegisterVerify';
 
 export default (
     <Route path="/" component={ App }>

--- a/resources/assets/js/app/store.js
+++ b/resources/assets/js/app/store.js
@@ -2,7 +2,7 @@ import { createStore, applyMiddleware } from 'redux';
 import logger from 'redux-logger';
 import thunk from 'redux-thunk';
 
-import reducer from './reducer';
+import reducer from 'app/reducer';
 
 const middleware = process.env.NODE_ENV === 'production' ?
     [ thunk ] :

--- a/resources/assets/js/features/user/actions.js
+++ b/resources/assets/js/features/user/actions.js
@@ -1,6 +1,6 @@
 import * as actions from './actionTypes';
 import axios from 'axios';
-import { RegisterValidate, VerifyValidator, RegisterValidator } from '../../app/services/UserService';
+import { RegisterValidate, VerifyValidator, RegisterValidator } from 'app/services/UserService';
 
 export const registerSuccess = data => ({
     type: actions.USER_REGISTER_SUCCESS,

--- a/resources/assets/js/features/user/components/Register/Form.js
+++ b/resources/assets/js/features/user/components/Register/Form.js
@@ -1,12 +1,12 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { doRegister } from '../../actions';
-import Input from '../../../../app/components/Input';
+import { doRegister } from 'user/actions';
+import Input from 'app/components/Input';
 import { browserHistory } from 'react-router';
-import '../../styles/user_register.scss';
+import 'user/styles/user_register.scss';
 
-class Form extends React.Component {
+class Form extends Component {
 
     constructor() {
         super();

--- a/resources/assets/js/features/user/layouts/RegisterForm.js
+++ b/resources/assets/js/features/user/layouts/RegisterForm.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 
-import PageHeader from '../../../app/components/PageHeader';
-import Form from '../components/Register/Form';
+import PageHeader from 'app/components/PageHeader';
+import Form from 'user/components/Register/Form';
 
 class RegisterForm extends Component {
 

--- a/resources/assets/js/features/user/layouts/RegisterSuccess.js
+++ b/resources/assets/js/features/user/layouts/RegisterSuccess.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 
-import PageHeader from '../../../app/components/PageHeader';
+import PageHeader from 'app/components/PageHeader';
 import { connect } from 'react-redux';
 import { browserHistory } from 'react-router';
 

--- a/resources/assets/js/features/user/layouts/RegisterVerify.js
+++ b/resources/assets/js/features/user/layouts/RegisterVerify.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { doVerify } from '../actions';
-import PageHeader from '../../../app/components/PageHeader';
+import { doVerify } from 'user/actions';
+import PageHeader from 'app/components/PageHeader';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { browserHistory } from 'react-router';

--- a/resources/assets/js/features/vehicle/components/VehicleProfile.js
+++ b/resources/assets/js/features/vehicle/components/VehicleProfile.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
-import { getVehicle } from '../actions';
+import { getVehicle } from 'vehicle/actions';
 
 class VehicleProfile extends Component {
 

--- a/resources/assets/js/features/vehicle/components/VehiclesList.js
+++ b/resources/assets/js/features/vehicle/components/VehiclesList.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
-import { getVehicles } from '../actions';
+import { getVehicles } from 'vehicle/actions';
 
 import VehicleItem from './VehicleItem';
 

--- a/resources/assets/js/features/vehicle/layouts/VehicleDetails.js
+++ b/resources/assets/js/features/vehicle/layouts/VehicleDetails.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
 
-import PageHeader from '../../../app/components/PageHeader';
-import VehicleProfile from '../components/VehicleProfile';
+import PageHeader from 'app/components/PageHeader';
+import VehicleProfile from 'vehicle/components/VehicleProfile';
 
-import '../styles/vehicle.scss';
+import 'vehicle/styles/vehicle.scss';
 
 class VehicleDetails extends Component {
 

--- a/resources/assets/js/features/vehicle/layouts/Vehicles.js
+++ b/resources/assets/js/features/vehicle/layouts/Vehicles.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
 
-import PageHeader from '../../../app/components/PageHeader';
-import VehiclesList from '../components/VehiclesList';
+import PageHeader from 'app/components/PageHeader';
+import VehiclesList from 'vehicle/components/VehiclesList';
 
-import '../styles/vehicle.scss';
+import 'vehicle/styles/vehicle.scss';
 
 class Vehicles extends Component {
 

--- a/resources/assets/js/index.js
+++ b/resources/assets/js/index.js
@@ -1,11 +1,10 @@
-//import 'babel-polyfill';
 import React from 'react';
 import { render } from 'react-dom';
 import { Provider } from 'react-redux';
 import { Router, browserHistory } from 'react-router';
 
-import Store from './app/store';
-import routes from './app/routes';
+import Store from 'app/store';
+import routes from 'app/routes';
 
 render(
     (<Provider store={ Store }>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,21 @@ const baseSettings = {
 const settings = baseSettings[process.env.NODE_ENV];
 
 module.exports = {
+    resolve: {
+        modules: [
+            path.join(__dirname, 'resources/assets/js'),
+            path.join(__dirname, 'resources/assets/js/features'),
+            'node_modules'
+        ],
+        alias: {
+            // Features aliases
+            user: path.join(__dirname, 'resources/assets/js/features/user'),
+            vehicle: path.join(__dirname, 'resources/assets/js/features/vehicle'),
+            trip: path.join(__dirname, 'resources/assets/js/features/trip'),
+            booking: path.join(__dirname, 'resources/assets/js/features/booking'),
+        },
+        extensions: ['.js', '.jsx', '.json', '.scss', '.jpg', '.png']
+    },
     module: {
         rules: [
             {


### PR DESCRIPTION
1) Fix `app/components/Input.js`

    It's wrong to write *'React'*, should *'reaсt'*. Otherwise, we will see many *npm* warnings.
    Change `import React from 'React';`  to  `import React, { Component } from 'react';`

2) Added *resolve section* to `/webpack.config.js` (https://webpack.js.org/configuration/resolve/)

    This allows to solve the problem `../../../../` and to change the code, for example:

    From
           `import PageHeader from '../../../app/components/PageHeader';`
    To
          `import PageHeader from 'app/components/PageHeader';`

    From
          `import Form from '../components/Register/Form';`
    To
           `import Form from 'user/components/Register/Form';`

    Old style with `../../../../` also still works.