### PR TITLE
Fixed react component name

### DIFF
--- a/resources/assets/js/app/components/Input.js
+++ b/resources/assets/js/app/components/Input.js
@@ -1,4 +1,4 @@
-import React from 'React';
+import React from 'react';
 
 class Input extends React.Component {
     render() {


### PR DESCRIPTION
Fix `app/components/Input.js`

It's wrong to write **'React'**, should **'reaсt'**. Otherwise, we will see many npm warnings.
Change `import React from 'React';` to `import React from 'react';`