### PR TITLE
Add validate.js to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9667,6 +9667,11 @@
         "spdx-expression-parse": "1.0.4"
       }
     },
+    "validate.js": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/validate.js/-/validate.js-0.11.1.tgz",
+      "integrity": "sha1-9Rw8bEpW5jgKIKfrEEJFA38qVA0="
+    },
     "vary": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "redux": "^3.7.2",
     "redux-logger": "^2.8.2",
     "redux-promise": "^0.5.3",
-    "redux-thunk": "^2.2.0"
+    "redux-thunk": "^2.2.0",
+    "validate.js": "^0.11.1"
   }
 }


### PR DESCRIPTION
Теперь можно валидировать поля не RegisterValidator.email(), а validate.single(email, {prescene: true, email: true}); 

И многое другое здесь https://validatejs.org/