### PR TITLE
Fixed invalid routes behavior with storage path

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -14,4 +14,4 @@
 Route::get('/{wildcard?}', function () {
     return view('index');
 })
-->where('wildcard', '^(?!api).+');
+->where('wildcard', '^(?!api|storage).+');


### PR DESCRIPTION
Invalid routing behavior. Non-existent storage resources do not return the 404 status code.