### PR TITLE
Removed empty mock links

### DIFF
--- a/resources/assets/js/app/components/MainNavigation/ForAuthUser.js
+++ b/resources/assets/js/app/components/MainNavigation/ForAuthUser.js
@@ -56,8 +56,6 @@ class ForAuthUser extends Component {
                   <div className="dropdown-menu dropdown-menu-right">
 
                     <Link to="/dashboard" className="dropdown-item">Dashboard</Link>
-                    <Link to="#" className="dropdown-item">My trips</Link>
-                    <Link to="#" className="dropdown-item">My bookings</Link>
                     <Link to="/dashboard/profile" className="dropdown-item">Profile</Link>
 
                     <div className="dropdown-divider"></div>


### PR DESCRIPTION
Removed empty mock links as `<Link to="#">`.
Do not show empty links to the product meeting tomorrow.

Result:

![links](https://user-images.githubusercontent.com/12577743/29431466-b34cd1ee-83a0-11e7-94c0-0b0dc7c6e70d.jpg)
