### PR TITLE
Hotfix/edit trip backend

### DIFF
--- a/app/Repositories/RouteRepository.php
+++ b/app/Repositories/RouteRepository.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Models\Route;
+use Prettus\Repository\Eloquent\BaseRepository;
+
+class RouteRepository extends BaseRepository
+{
+    /**
+     * @return string
+     */
+    public function model()
+    {
+        return Route::class;
+    }
+}


### PR DESCRIPTION
Fixed `TripService.php`:

1. Method `show()` - return `->first();`.  It is necessary to return one Trip entity for frontend part.
2. Method `update()` - when updating trip data there is an *error 500* - 
    the problem in `$result->routes()->update(...)`.  
3. Added `user_can_edit_trip_successfully()` method is `UpdateTripTest`

The code is reworked using the `RouteRepository`. It successfully updates the route data.