### PR TITLE
Fix/user avatar saving mimetypes

### DIFF
--- a/app/Http/Controllers/User/AvatarController.php
+++ b/app/Http/Controllers/User/AvatarController.php
@@ -49,7 +49,7 @@ class AvatarController extends Controller
             $avatar = $this->userProfileService->updateAvatar(Auth::user(), $request);
         } catch (FileCannotBeAdded $e) {
             return response()->json([
-                'error' => __('Http/Controllers/User/AvatarController.file_cannot_be_added')
+                'error' => __('Http/Controllers/User/AvatarController.file_cannot_be_added'),
             ], 422);
         }
 

--- a/app/Http/Controllers/User/AvatarController.php
+++ b/app/Http/Controllers/User/AvatarController.php
@@ -31,7 +31,7 @@ class AvatarController extends Controller
      */
     public function show(): JsonResponse
     {
-        $avatar = $this->userProfileService->getAvatar(Auth::user()->id);
+        $avatar = $this->userProfileService->getAvatar(Auth::user());
 
         return response()->json(['avatar' => $avatar]);
     }
@@ -46,9 +46,11 @@ class AvatarController extends Controller
     public function update(UpdateUserAvatarRequest $request): JsonResponse
     {
         try {
-            $avatar = $this->userProfileService->updateAvatar(Auth::user()->id, $request);
+            $avatar = $this->userProfileService->updateAvatar(Auth::user(), $request);
         } catch (FileCannotBeAdded $e) {
-            return response()->json(['error' => __('Http/Controllers/User/AvatarController.file_cannot_be_added')], 422);
+            return response()->json([
+                'error' => __('Http/Controllers/User/AvatarController.file_cannot_be_added')
+            ], 422);
         }
 
         return response()->json(['avatar' => $avatar]);
@@ -61,7 +63,7 @@ class AvatarController extends Controller
      */
     public function destroy(): JsonResponse
     {
-        $this->userProfileService->deleteAvatar(Auth::user()->id);
+        $this->userProfileService->deleteAvatar(Auth::user());
 
         return response()->json();
     }

--- a/app/Http/Controllers/User/ProfileController.php
+++ b/app/Http/Controllers/User/ProfileController.php
@@ -31,7 +31,7 @@ class ProfileController extends Controller
      */
     public function show(): JsonResponse
     {
-        $user = $this->userProfileService->getGeneral(Auth::user()->id);
+        $user = $this->userProfileService->getGeneral(Auth::user());
 
         return fractal($user, new ProfileTransformer())->respond();
     }
@@ -45,7 +45,7 @@ class ProfileController extends Controller
      */
     public function update(UpdateUserProfileRequest $request): JsonResponse
     {
-        $user = $this->userProfileService->updateGeneral(Auth::user()->id, $request);
+        $user = $this->userProfileService->updateGeneral(Auth::user(), $request);
 
         return fractal($user, new ProfileTransformer())->respond();
     }

--- a/app/Http/Requests/UpdateUserAvatarRequest.php
+++ b/app/Http/Requests/UpdateUserAvatarRequest.php
@@ -31,7 +31,7 @@ class UpdateUserAvatarRequest extends FormRequest implements UpdateUserAvatarReq
     }
 
     /**
-     * @return string
+     * {@inheritdoc}
      */
     public function getAvatar(): string
     {

--- a/app/Services/AuthUserService.php
+++ b/app/Services/AuthUserService.php
@@ -38,7 +38,9 @@ class AuthUserService
      * Auth service.
      *
      * @param LoginRequest $request
+     *
      * @return mixed
+     *
      * @throws CreateTokenException
      * @throws InvalidCredentialsException
      * @throws UserNotFoundException
@@ -98,6 +100,7 @@ class AuthUserService
      * Set custom claims for JWT Token payload data.
      *
      * @param User $user
+     *
      * @return AuthUserService
      */
     private function setCustomClaims(User $user): self

--- a/app/Services/Contracts/UserProfileService.php
+++ b/app/Services/Contracts/UserProfileService.php
@@ -11,38 +11,47 @@ interface UserProfileService
     /**
      * Get the user profile general data.
      *
-     * @param int $userId
+     * @param \App\User $user
      *
      * @return \App\User
      */
-    public function getGeneral(int $userId): User;
+    public function getGeneral(User $user): User;
+
+    /**
+     * Get the user profile avatar.
+     *
+     * @param \App\User $user
+     *
+     * @return string|null
+     */
+    public function getAvatar(User $user): ?string;
 
     /**
      * Update the user profile general data.
      *
-     * @param int $userId
+     * @param \App\User $user
      * @param \App\Services\Requests\UpdateUserProfileRequest $request
      *
      * @return \App\User
      */
-    public function updateGeneral(int $userId, UpdateUserProfileRequest $request): User;
+    public function updateGeneral(User $user, UpdateUserProfileRequest $request): User;
 
     /**
      * Update the user profile avatar.
      *
-     * @param int $userId
+     * @param \App\User $user
      * @param \App\Services\Requests\UpdateUserAvatarRequest $request
      *
      * @return string The avatar image full url
      */
-    public function updateAvatar(int $userId, UpdateUserAvatarRequest $request): string;
+    public function updateAvatar(User $user, UpdateUserAvatarRequest $request): string;
 
     /**
      * Delete the user profile avatar.
      *
-     * @param int $userId
+     * @param \App\User $user
      *
      * @return void
      */
-    public function deleteAvatar(int $userId): void;
+    public function deleteAvatar(User $user): void;
 }

--- a/app/Services/RegisterUserService.php
+++ b/app/Services/RegisterUserService.php
@@ -60,6 +60,7 @@ class RegisterUserService
      * @param \App\Services\Requests\VerifyUserRequest $request
      *
      * @return string
+     *
      * @throws \App\Exceptions\User\VerifyException
      */
     public function verify(VerifyUserRequest $request): string
@@ -97,6 +98,7 @@ class RegisterUserService
      * Set custom claims for JWT Token payload data.
      *
      * @param User $user
+     *
      * @return RegisterUserService
      */
     private function setCustomClaims(User $user): self

--- a/app/Services/Requests/UpdateUserAvatarRequest.php
+++ b/app/Services/Requests/UpdateUserAvatarRequest.php
@@ -4,5 +4,8 @@ namespace App\Services\Requests;
 
 interface UpdateUserAvatarRequest
 {
+    /**
+     * @return string
+     */
     public function getAvatar(): string;
 }

--- a/app/Services/UserProfileService.php
+++ b/app/Services/UserProfileService.php
@@ -26,25 +26,23 @@ class UserProfileService implements UserProfileServiceContract
     /**
      * {@inheritdoc}
      */
-    public function getGeneral(int $userId): User
+    public function getGeneral(User $user): User
     {
-        return $this->userRepository->find($userId);
+        return $user;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getAvatar(int $userId): ?string
+    public function getAvatar(User $user): ?string
     {
-        return $this->userRepository
-            ->find($userId)
-            ->getAvatarUrl();
+        return $user->getAvatarUrl();
     }
 
     /**
      * {@inheritdoc}
      */
-    public function updateGeneral(int $userId, UpdateUserProfileRequest $request): User
+    public function updateGeneral(User $user, UpdateUserProfileRequest $request): User
     {
         $attributes = [
             'email' => $request->getEmail(),
@@ -56,36 +54,30 @@ class UserProfileService implements UserProfileServiceContract
             'permissions' => $request->getPermissions(),
         ];
 
-        $this->userRepository->update($attributes, $userId);
-
-        return $this->getGeneral($userId);
+        return $this->userRepository->update($attributes, $user->id);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function updateAvatar(int $userId, UpdateUserAvatarRequest $request): string
+    public function updateAvatar(User $user, UpdateUserAvatarRequest $request): string
     {
-        $user = $this->userRepository->find($userId);
-
         $fileName = str_random(20);
-        $mimeTypes = 'image/*';
 
-        return $user
-            ->deleteAvatar()
-            ->addMediaFromBase64($request->getAvatar(), $mimeTypes)
+        $user->deleteAvatar()
+            ->addMediaFromBase64($request->getAvatar(), User::MEDIA_AVATAR_ALLOWED_MIMETYPES)
             ->usingName($fileName)
             ->usingFileName($fileName)
-            ->toMediaCollection(User::MEDIA_AVATARS_COLLECTION)
-            ->getUrl();
+            ->toMediaCollection(User::MEDIA_AVATARS_COLLECTION);
+
+        return $user->getAvatarUrl();
     }
 
     /**
      * {@inheritdoc}
      */
-    public function deleteAvatar(int $userId): void
+    public function deleteAvatar(User $user): void
     {
-        $user = $this->userRepository->find($userId);
         $user->deleteAvatar();
     }
 }

--- a/app/Services/UserProfileService.php
+++ b/app/Services/UserProfileService.php
@@ -65,7 +65,10 @@ class UserProfileService implements UserProfileServiceContract
         $fileName = str_random(20);
 
         $user->deleteAvatar()
-            ->addMediaFromBase64($request->getAvatar(), User::MEDIA_AVATAR_ALLOWED_MIMETYPES)
+            ->addMediaFromBase64(
+                $request->getAvatar(),
+                User::MEDIA_AVATAR_ALLOWED_MIMETYPES
+            )
             ->usingName($fileName)
             ->usingFileName($fileName)
             ->toMediaCollection(User::MEDIA_AVATARS_COLLECTION);

--- a/app/User.php
+++ b/app/User.php
@@ -9,10 +9,10 @@ use App\Models\Vehicle;
 use Spatie\MediaLibrary\Media;
 use Illuminate\Notifications\Notifiable;
 use Spatie\MediaLibrary\HasMedia\HasMediaTrait;
-use Spatie\MediaLibrary\HasMedia\Interfaces\HasMedia;
 use Illuminate\Foundation\Auth\User as Authenticatable;
+use Spatie\MediaLibrary\HasMedia\Interfaces\HasMediaConversions;
 
-class User extends Authenticatable implements HasMedia
+class User extends Authenticatable implements HasMediaConversions
 {
     use Notifiable, HasMediaTrait;
 
@@ -21,6 +21,9 @@ class User extends Authenticatable implements HasMedia
     const ADMIN_PERMISSION = 4;
 
     const MEDIA_AVATARS_COLLECTION = 'avatars';
+    const MEDIA_AVATAR_ALLOWED_MIMETYPES = 'image/jpeg,image/png';
+    const MEDIA_AVATAR_SIZE = 150;
+    const MEDIA_AVATAR_CONVERSION = 'avatar_' . self::MEDIA_AVATAR_SIZE;
 
     /**
      * Boot the model.
@@ -189,33 +192,49 @@ class User extends Authenticatable implements HasMedia
     }
 
     /**
+     * Register media conversions for the user avatar image.
+     *
+     * @return void
+     */
+    public function registerMediaConversions(): void
+    {
+        $this->addMediaConversion(self::MEDIA_AVATAR_CONVERSION)
+              ->performOnCollections(self::MEDIA_AVATARS_COLLECTION)
+              ->width(self::MEDIA_AVATAR_SIZE)
+              ->height(self::MEDIA_AVATAR_SIZE)
+              ->optimize();
+    }
+
+    /**
      * Get the user avatar media instance.
      *
      * @return \Spatie\MediaLibrary\Media|null
      */
-    public function getAvatar(): ?Media
+    public function getAvatarMedia(): ?Media
     {
         return $this->getFirstMedia(self::MEDIA_AVATARS_COLLECTION);
     }
 
     /**
-     * Get the full url of the user avatar.
+     * Get the user avatar.
      *
      * @param  bool $fullUrl
+     *
      * @return string|null
      */
     public function getAvatarUrl(bool $fullUrl = false): ?string
     {
-        $avatar = $this->getAvatar();
+        $avatar = $this->getAvatarMedia();
 
         if ($avatar === null) {
             return null;
         }
+
         if ($fullUrl) {
-            return $this->getAvatar()->getFullUrl();
+            return $avatar->getFullUrl(self::MEDIA_AVATAR_CONVERSION);
         }
 
-        return $this->getAvatar()->getUrl();
+        return $avatar->getUrl(self::MEDIA_AVATAR_CONVERSION);
     }
 
     /**

--- a/app/User.php
+++ b/app/User.php
@@ -23,7 +23,7 @@ class User extends Authenticatable implements HasMediaConversions
     const MEDIA_AVATARS_COLLECTION = 'avatars';
     const MEDIA_AVATAR_ALLOWED_MIMETYPES = 'image/jpeg,image/png';
     const MEDIA_AVATAR_SIZE = 150;
-    const MEDIA_AVATAR_CONVERSION = 'avatar_' . self::MEDIA_AVATAR_SIZE;
+    const MEDIA_AVATAR_CONVERSION = 'avatar_'.self::MEDIA_AVATAR_SIZE;
 
     /**
      * Boot the model.

--- a/resources/assets/js/app/components/FilesDropzone.js
+++ b/resources/assets/js/app/components/FilesDropzone.js
@@ -82,12 +82,12 @@ class FilesDropzone extends React.Component {
                     { translate('files_dropzone.drop_or_click_to_select_file_to_upload') }
                 </p>
                 <p className="files-dropzone__rules">
-                    <span className="mr-2">
+                    <span>{ customRules }</span>
+                    <span className="ml-2">
                         { translate('files_dropzone.rule_max_size_mb', {
                             size: fileMaxSizeMb
                         }) }
                     </span>
-                    <span>{ customRules }</span>
                 </p>
             </Dropzone>
         );

--- a/resources/assets/js/features/user/components/Profile/AvatarCurrent.js
+++ b/resources/assets/js/features/user/components/Profile/AvatarCurrent.js
@@ -29,7 +29,7 @@ class AvatarCurrent extends React.Component {
                     </figcaption>
                     <img src={ avatar }
                         className="user-current-avatar__image"
-                        alt={ translate('profile_avatar.user_current_avatar') } />
+                        alt={ translate('profile_avatar.current_avatar') } />
                 </figure>
 
                 { this.renderDeleteButton() }

--- a/resources/assets/js/features/user/components/Profile/AvatarCurrent.js
+++ b/resources/assets/js/features/user/components/Profile/AvatarCurrent.js
@@ -19,7 +19,7 @@ class AvatarCurrent extends React.Component {
     }
 
     render() {
-        const { translate, avatar } = this.props;
+        const { translate, avatar, destWidth } = this.props;
 
         return (
             <div className="user-current-avatar">
@@ -29,7 +29,8 @@ class AvatarCurrent extends React.Component {
                     </figcaption>
                     <img src={ avatar }
                         className="user-current-avatar__image"
-                        alt={ translate('profile_avatar.current_avatar') } />
+                        alt={ translate('profile_avatar.current_avatar') }
+                        style={{ maxWidth: destWidth }} />
                 </figure>
 
                 { this.renderDeleteButton() }

--- a/resources/assets/js/features/user/components/Profile/AvatarUpload.js
+++ b/resources/assets/js/features/user/components/Profile/AvatarUpload.js
@@ -7,8 +7,7 @@ import AvatarCurrent from './AvatarCurrent';
 
 import UserService from 'features/user/services/UserService';
 
-const AVATAR_WIDTH = 150;
-const AVATAR_HEIGHT = 150;
+const AVATAR_SIZE = 150;
 const AVATAR_MIME_TYPES = 'image/jpeg, image/png';
 const AVATAR_MAX_SIZE_MB = 10;
 
@@ -132,8 +131,8 @@ class AvatarUpload extends React.Component {
                     <div className="col-md-8">
                         <ImageCropper
                             image={ image.preview }
-                            destWidth={ AVATAR_WIDTH }
-                            destHeight={ AVATAR_HEIGHT }
+                            destWidth={ AVATAR_SIZE }
+                            destHeight={ AVATAR_SIZE }
                             toggleShow={ toggleShow }
                             ref={ cropper => { this.onInitCropper(cropper); } }
                         />
@@ -143,6 +142,7 @@ class AvatarUpload extends React.Component {
                 <div className="mt-5">
                     <AvatarCurrent
                         avatar={ avatarCurrent }
+                        destWidth={ AVATAR_SIZE }
                         isDefault={ isDefaultAvatar }
                         onDelete={ this.onDelete }
                     />

--- a/resources/assets/js/features/user/components/Profile/AvatarUpload.js
+++ b/resources/assets/js/features/user/components/Profile/AvatarUpload.js
@@ -8,7 +8,7 @@ import AvatarCurrent from './AvatarCurrent';
 import UserService from 'features/user/services/UserService';
 
 const AVATAR_SIZE = 150;
-const AVATAR_MIME_TYPES = 'image/jpeg, image/png';
+const AVATAR_MIME_TYPES = 'image/jpeg,image/png';
 const AVATAR_MAX_SIZE_MB = 10;
 
 class AvatarUpload extends React.Component {

--- a/resources/assets/js/features/user/components/Profile/AvatarUpload.js
+++ b/resources/assets/js/features/user/components/Profile/AvatarUpload.js
@@ -7,9 +7,9 @@ import AvatarCurrent from './AvatarCurrent';
 
 import UserService from 'features/user/services/UserService';
 
-const AVATAR_WIDTH = 100;
-const AVATAR_HEIGHT = 100;
-const AVATAR_MIME_TYPES = 'image/*';
+const AVATAR_WIDTH = 150;
+const AVATAR_HEIGHT = 150;
+const AVATAR_MIME_TYPES = 'image/jpeg, image/png';
 const AVATAR_MAX_SIZE_MB = 10;
 
 class AvatarUpload extends React.Component {
@@ -115,6 +115,7 @@ class AvatarUpload extends React.Component {
                             fileMaxSizeMb={ AVATAR_MAX_SIZE_MB }
                             onDropAcceptedCustom={ this.onDropAccepted }
                             onDropRejectedCustom={ this.onDropRejected }
+                            customRules={ translate('profile_avatar.custom_rules') }
                         />
 
                         <div className={ "mt-3 text-right" + classShow }>

--- a/resources/assets/js/features/user/lang/Profile/ProfileAvatar.locale.json
+++ b/resources/assets/js/features/user/lang/Profile/ProfileAvatar.locale.json
@@ -16,10 +16,10 @@
     "save_avatar": [
       "Save", "Зберегти", "Сохранить"
     ],
-    "user_current_avatar": [
-      "User current avatar",
-      "Поточний аватар користувача",
-      "Текущий аватар пользователя"
+    "custom_rules": [
+      "JPG or PNG.",
+      "JPG або PNG.",
+      "JPG или PNG."
     ]
   }
 }

--- a/resources/assets/js/features/user/layouts/Profile/ProfileAvatar.js
+++ b/resources/assets/js/features/user/layouts/Profile/ProfileAvatar.js
@@ -9,7 +9,7 @@ import PageHeader from 'app/components/PageHeader';
 import AvatarUpload from 'features/user/components/Profile/AvatarUpload';
 import StatusModal from 'features/user/components/_Modals/StatusModal';
 
-import { getProfileAvatar, isDefaultProfileAvatar } from 'app/services/PhotoService';
+import { isDefaultProfileAvatar } from 'app/services/PhotoService';
 import LangService from 'app/services/LangService';
 import * as lang from 'features/user/lang/Profile/ProfileAvatar.locale.json';
 

--- a/resources/assets/js/features/user/styles/profile_avatar.scss
+++ b/resources/assets/js/features/user/styles/profile_avatar.scss
@@ -12,7 +12,7 @@
         font-size: 1.5em;
     }
     &__image {
-        max-width: 100px;
+        max-width: 150px;
         border-radius: 50%;
     }
 }

--- a/resources/lang/en/Http/Controllers/User/AvatarController.php
+++ b/resources/lang/en/Http/Controllers/User/AvatarController.php
@@ -1,5 +1,5 @@
 <?php
 
 return [
-    'file_cannot_be_added' => 'File can not be added',
+    'file_cannot_be_added' => 'File cannot be added.',
 ];

--- a/resources/lang/ru/Http/Controllers/User/AvatarController.php
+++ b/resources/lang/ru/Http/Controllers/User/AvatarController.php
@@ -1,5 +1,5 @@
 <?php
 
 return [
-    'file_cannot_be_added' => 'Файл не может быть добавлен',
+    'file_cannot_be_added' => 'Файл не может быть добавлен.',
 ];

--- a/resources/lang/uk/Http/Controllers/User/AvatarController.php
+++ b/resources/lang/uk/Http/Controllers/User/AvatarController.php
@@ -1,5 +1,5 @@
 <?php
 
 return [
-    'file_cannot_be_added' => 'Не можливо додати файл',
+    'file_cannot_be_added' => 'Файл не може бути доданий.',
 ];

--- a/tests/Feature/User/AvatarTest.php
+++ b/tests/Feature/User/AvatarTest.php
@@ -154,7 +154,8 @@ class AvatarTest extends JwtTestCase
      *
      * @return \Illuminate\Foundation\Testing\TestResponse
      */
-    private function jsonRequestFromGuest(string $type = 'get') {
+    private function jsonRequestFromGuest(string $type = 'get')
+    {
         return $this->json($this->routes[$type][0], $this->routes[$type][1]);
     }
 

--- a/tests/Feature/User/AvatarTest.php
+++ b/tests/Feature/User/AvatarTest.php
@@ -4,7 +4,6 @@ namespace Tests\Feature\User;
 
 use App\User;
 use Tests\JwtTestCase;
-use Illuminate\Support\Facades\Artisan;
 
 class AvatarTest extends JwtTestCase
 {
@@ -20,7 +19,6 @@ class AvatarTest extends JwtTestCase
     public function setUp()
     {
         parent::setUp();
-        Artisan::call('migrate:refresh');
 
         $this->routes['get'][] = route('user.profile.avatar.show');
         $this->routes['update'][] = route('user.profile.avatar.update');
@@ -32,7 +30,7 @@ class AvatarTest extends JwtTestCase
      */
     public function guest_can_not_get_avatar()
     {
-        $response = $this->json($this->routes['get'][0], $this->routes['get'][1]);
+        $response = $this->jsonRequestFromGuest();
         $response->assertStatus(400);
     }
 
@@ -41,7 +39,7 @@ class AvatarTest extends JwtTestCase
      */
     public function guest_can_not_update_avatar()
     {
-        $response = $this->json($this->routes['update'][0], $this->routes['update'][1]);
+        $response = $this->jsonRequestFromGuest('update');
         $response->assertStatus(400);
     }
 
@@ -50,7 +48,7 @@ class AvatarTest extends JwtTestCase
      */
     public function guest_can_not_delete_avatar()
     {
-        $response = $this->json($this->routes['delete'][0], $this->routes['delete'][1]);
+        $response = $this->jsonRequestFromGuest('delete');
         $response->assertStatus(400);
     }
 
@@ -60,10 +58,9 @@ class AvatarTest extends JwtTestCase
     public function user_can_get_empty_avatar()
     {
         $user = $this->createUser();
-        $response = $this->jsonRequestAvatar($user);
+        $response = $this->jsonRequestUserAvatar($user);
 
-        $response->assertStatus(200)
-             ->assertExactJson(['avatar' => null]);
+        $response->assertStatus(200)->assertExactJson(['avatar' => null]);
     }
 
     /**
@@ -74,15 +71,15 @@ class AvatarTest extends JwtTestCase
         $user = $this->createUser();
 
         // Error - the empty data
-        $response = $this->jsonRequestAvatar($user, 'update');
+        $response = $this->jsonRequestUserAvatar($user, 'update');
         $response->assertStatus(422);
 
         // Error - the avatar is required
-        $response = $this->jsonRequestAvatar($user, 'update', ['avatar' => null]);
+        $response = $this->jsonRequestUserAvatar($user, 'update', ['avatar' => null]);
         $response->assertStatus(422);
 
         // Error - the avatar is not string
-        $response = $this->jsonRequestAvatar($user, 'update', ['avatar' => 123]);
+        $response = $this->jsonRequestUserAvatar($user, 'update', ['avatar' => 123]);
         $response->assertStatus(422)->assertJsonStructure(['avatar' => []]);
     }
 
@@ -91,7 +88,9 @@ class AvatarTest extends JwtTestCase
         $user = $this->createUser();
 
         // Error - the avatar is not data:URL base64
-        $response = $this->jsonRequestAvatar($user, 'update', ['avatar' => 'Lorem ipsum dolor.']);
+        $response = $this->jsonRequestUserAvatar($user, 'update', [
+            'avatar' => 'Lorem ipsum dolor.',
+        ]);
         $response->assertStatus(422)->assertJsonStructure(['error' => '']);
     }
 
@@ -101,7 +100,9 @@ class AvatarTest extends JwtTestCase
         $dataBase64 = 'data:text/html;charset=utf-8,%3C!DOCTYPE%20HTML%20PUBLIC%20%22-%2F%2FW3C%2F%2FDTD%20HTML%204.0%2F%2FEN%22%3E%0D%0A%3Chtml%20lang%3D%22en%22%3E%0D%0A%3Chead%3E%3Ctitle%3EEmbedded%20Window%3C%2Ftitle%3E%3C%2Fhead%3E%0D%0A%3Cbody%3E%3Ch1%3E42%3C%2Fh1%3E%3C%2Fbody%3E%0D%0A%3C%2Fhtml%3E%0D%0A';
 
         // Error - the avatar has invalid mimetype
-        $response = $this->jsonRequestAvatar($user, 'update', ['avatar' => $dataBase64]);
+        $response = $this->jsonRequestUserAvatar($user, 'update', [
+            'avatar' => $dataBase64,
+        ]);
         $response->assertStatus(422)->assertJsonStructure(['error' => '']);
     }
 
@@ -112,7 +113,9 @@ class AvatarTest extends JwtTestCase
         config(['medialibrary.max_file_size' => 1024 * 1024 * 2]);
 
         // Error - the avatar image size exceeds max_file_size
-        $response = $this->jsonRequestAvatar($user, 'update', ['avatar' => $dataBase64]);
+        $response = $this->jsonRequestUserAvatar($user, 'update', [
+            'avatar' => $dataBase64,
+        ]);
         $response->assertStatus(422)->assertJsonStructure(['error' => '']);
     }
 
@@ -121,7 +124,9 @@ class AvatarTest extends JwtTestCase
         $user = $this->createUser();
         $dataBase64 = $this->getImage();
 
-        $response = $this->jsonRequestAvatar($user, 'update', ['avatar' => $dataBase64]);
+        $response = $this->jsonRequestUserAvatar($user, 'update', [
+            'avatar' => $dataBase64,
+        ]);
         $response->assertStatus(200)->assertJsonStructure(['avatar' => '']);
     }
 
@@ -130,19 +135,31 @@ class AvatarTest extends JwtTestCase
         $user = $this->createUser();
         $dataBase64 = $this->getImage();
 
-        $response = $this->jsonRequestAvatar($user, 'update', ['avatar' => $dataBase64]);
+        $response = $this->jsonRequestUserAvatar($user, 'update', [
+            'avatar' => $dataBase64,
+        ]);
         $response->assertStatus(200)->assertJsonStructure(['avatar' => '']);
 
-        $response = $this->jsonRequestAvatar($user, 'delete');
+        $response = $this->jsonRequestUserAvatar($user, 'delete');
         $response->assertStatus(200);
 
-        $response = $this->jsonRequestAvatar($user);
-        $response->assertStatus(200)
-             ->assertExactJson(['avatar' => null]);
+        $response = $this->jsonRequestUserAvatar($user);
+        $response->assertStatus(200)->assertExactJson(['avatar' => null]);
     }
 
     /**
-     * Send request on the user avatar.
+     * Send request to the user avatar from the guest user.
+     *
+     * @param string $type
+     *
+     * @return \Illuminate\Foundation\Testing\TestResponse
+     */
+    private function jsonRequestFromGuest(string $type = 'get') {
+        return $this->json($this->routes[$type][0], $this->routes[$type][1]);
+    }
+
+    /**
+     * Send request to the user avatar.
      *
      * @param \App\User $user
      * @param string $type
@@ -150,8 +167,11 @@ class AvatarTest extends JwtTestCase
      *
      * @return \Illuminate\Foundation\Testing\TestResponse
      */
-    private function jsonRequestAvatar(User $user, string $type = 'get', array $updatedData = [])
-    {
+    private function jsonRequestUserAvatar(
+        User $user,
+        string $type = 'get',
+        array $updatedData = []
+    ) {
         return $this->jsonRequestAsUser(
             $user,
             $this->routes[$type][0],
@@ -170,7 +190,10 @@ class AvatarTest extends JwtTestCase
         return factory(User::class)->create();
     }
 
-    private function getImage()
+    /**
+     * @return string
+     */
+    private function getImage(): string
     {
         return 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/2wBDAQMDAwQDBAgEBAgQCwkLEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBD/wAARCABkAGQDASIAAhEBAxEB/8QAHQAAAgMBAQEBAQAAAAAAAAAABgcABQgEAwkCAf/EADkQAAEDAwMBBgQGAAQHAAAAAAECAwQABREGEiExBxMiQVFhCBRxgRUjMkJSkRczofEWJGJywdHw/8QAHAEAAgMBAQEBAAAAAAAAAAAABgcDBAUIAQIJ/8QANxEAAQIEAwQIAwgDAAAAAAAAAQIDAAQFEQYhMRJBUWEHExSBkaGxwTJCcSIjUoKy0fDxFVNj/9oADAMBAAIRAxEAPwDSUX4PNNSZCJMi/wAsxkg7mkJSCfbNC2rfhmhW5wSdPNvFpCuW33OSPUGtHW7VURxvYhwZNS5OtyW3HlupDe3Bz0Ao4ZxPVUuguOEjh/UDjlEkSiyUWMY+1LYdS2W3fM26bJZbjK2LbQ5v49RQ5b9b3q2thCLvJXuVuWhZ4z6UzO0i827Td7kMOT2fkpniDaXMq91DHlStamablXF5+3xVrisguLkPLyBjrgDrRDOYxolFlyaosbVr2AurPcRuP1MVafhCs1x4f41s7OlybJy3g8ONoJmZ8i7xi7a4ExyW+cpU0hSiT714wtR6s0rf4zuoYL8ZJOAVoIyn1zVnZ9U3X5UPRpSo0bbhtpvw8eWcVaO3B6TGQuWsvqc6d54uPPrSye6aqSh1TSZRSkG4uVC/oYZ7HQlVVtpcXNJSrgEkj2hoWPtEtk6IlaZrbgxzhVC+tL9Yn1OzY/cqdbQd6SB4h6UFMFmNPjNx4zbe5CnFYGN3OKs5Vis1yQHJNubKlnClDINZcp0pUJmZ2lNOBPLZPlcRam+iisljZD7ZVz2h52MJXVL0O73RyVb7cWArgpQMDP0qsm2KZCbbdfYWlLgyMpxTnmdm8BaN9qf7haTnYtO4f31oY1nEusWMlq7wFpLfhaeScoI+tO7DmPKJiIoZpzwKvwqyV4HXuJhO4gwPWcPhT0+0dn8Sc0+I07wIWJje1fn5TngVcFgnk1+Qxj9tHloCbxWC2PLG5KAR9RUqy7g+RxUr5sY92hGn9Mai1FJPeRoAdCeSFEpz96BPiG+Mo9l1v/4OtVuaTqOUwVrLhCkw2v5qHmo+Qo31pqN3s10PddaS1tfK22Mt7YTglXRKfuSBXyj1Nqe7691pM1JqGYt6Rc5JefUsk4STnH0A8qQ+I5xiXbKWEAKOhBNx7Q4MPSLs07tPKJSN3Ew3l60vmpFx5tznvzJ1xcVIkulZyhOfCn29cU7bfsTbbLY0H8yb/wAzIHRXdp4H2Jz/AFWc+zl1l6VFQsjfKlFKE842f7U/HgyO1SHFiyAFR7Q0h5rPqSoEenBFIDELzjj+xe5spXt768o6Hw0022xtkWBKU92vtpzhnJaUENRmTgAg8VbrkIekpjNHIjJCDj+XnVFYJyZV6EN1QCknaPfFWdoaUbgsKOSXCc+vNL7rVNp+1qYZCwlRuPlF4sZJCLvGYON6I4JHpk0TsMkwivPQjHFCVybLesZJHUMMJI9PDRxBAXaluYUsYCR9c1bTZT5QNw9oxJlZDKF8f3j2gsJLni/cn0rpkW+HPiLhTWEOtqGxSVDINWFutoEhDalA5Ga6EW4mbITt4Tg4NazCXpYpcaJCgciNQfrA5MvNPbTbmaSMwdCNITd67IVNzW/wp1SmH148Q/yh/wCq/L/Yhdm1BKJ7Jz6g041J7pzYB9jVdOvawVRUgJIOD610xgXpIqNYlOzTCrutZEkZqG4nnuPjvjnbGeBZGlzXaJdNmnNANEnePpvHhuhaN9gl3WgKNxZGf+k1KaUe/OoaCVLyalGZxNUr/EPAQICgyVvhPjGUfjX13LY0bbdGR3nki5u/MPJUf1No4T9ic/1WJo21uQVuJykBQ/0xWkPjJmyn+1h+0SXO8TbIjLTQB4TlO4j+yazqEpCXAoc76WWJphL80vZ00EMjDjBYlUbWusMfs5ShOobO8GyhLSRvHpkDn+qbr0027tlushxRfSuFFCc8YSWxikf2dXR9V9ipTt2owlQJpqyLv8x2vXFsBCh8nHSPbagcUl66wozTi/8Amf1Aw7MPvoEq2kf7B+kiHPpaW7JvLlxZOW2m8HB/cBzRTpOU7LWy85nO85PrzS80m7MtsC7NApLhaW+17hQ6UcaDkKlmMlSdi0hJwk8H60BzCLEqGYBAHlB+hy7ZvkSLmL1yQZOrrr3qduyQGQfZKRR5bVFu0pbRzveSKWEB0Pax1IkO+FNxcwCenA4pk294CFASD4g8VEeoxVtDpE24o/zQRjzSB2ZoDgPS8G9maBmsqxyU4q5itd1dHSpG7KwF8VS2uYj8QZLagdgHB9fOr5qUhu6PpUPzFYVj1zRhKlBSn6+0Ak5t7Zy3e8VF6abROd7tOAORQFq+C83cES46ylLowfrTAvL3fSFkp25TjH0NUdzYhPsNOTMltKNxI6g1q4SqRp1fbKdFnZP5sh52jGxHJCfoy0q1QNoflzPleBCPb5jjQUZB/upRMhWm0oSEF4jHXpUrozs0wfkPhCJ7Qz+IR89/iXUJvbDqF0rKgZSkoUfNIHFIx4FLjqSk8KzWhPiltLlr7U5jqkENy0NSEHHBykBX+uaQk1CUy3M9F80tMQky8863wUYYuHSJqRad4pBjs0m+5Au7ExAyEuDwmiu33uV/ibOmJKtzrucZ6A0GWyUmNKZcWApIWkqH0ooujqIOvGp8UYDrDbp+pTzQBPfeurSofEg+VoYtOu2ygpPwrSfG4vGldOTfn7TcMn88RnP1H26f1RX2fS3nG4qmyEqbSlKznkj3pdaVfbRGfktcokRHHN6TwfAciifsourbnyzhBT36RtBHn70q5gFttzZ3Ea/zlDXQQu21ncGL7TFxEnXOq2XQSE3Vzp64FNaJLU3CYKyQqO+Cg46g0hNIXV0a91UT1RdHd6cfTFNlTq1QEPtOLAB8Sc+flUcytSZhVuA9BEKZbrWG76aeohhQrulue24k5JGcjr1ogN6cbuPeurKVKSOCOoFKW03aU5JbQrKQlON+eSc0STZ5XJZJcVyjIyauy9VLaL3zv7RiTdJHWBJG4wcT7kiRhxCgSU881yJkgNtqxuIydp88eVDTc1SAkqX4VV2x5m9QwenSpGqvaaS6DmCD53jMepo6ktbiCPaKe4znpEtx1hJZQTwgHpUq1kxYCnlKbDmDyePPzqV+hkq+2thCgm1wPSOFJpLqH1p29Cd/OM6fG9o5aLTZdVNoJDanILygOBnxI59zu/qsXT0qdQh5PXooenrX1P7cNHDtJ7OLrpRCUqfW38xEKWz4X0cp/vkfevlvd2JFqnybXPZUy+w4pt1pYwpCwcEYpB44YdRO9qKbBYHiMofGBHmVSXZAq5QfI5xxNJKSOeh61fXeal6bbblkH8lDSx/28VQIWFE5PSvUr3o69ORS/db21hR5+cM2VOwgpHLyh56TvPyogwGZIUzLbUkpz0J4o57Ib3HfQmKokLjLUg8cDCiKRGj5wdbjud8UOxHBnxfszxRl2W6h/BNZTLZc1d0HZJI9OTmgWrUzaaeA1Av4E/vDEpc/dbV8gcvED9jDAsTz0ftZ1WPCW5EtShz7CnHFlyPwxS0keFScg1nGRen7D2vXmPJJDEuQHUqHOEqAwaczOoMWlt9pYIddQ2DnO4Z5NC1ZZcQtpwaKSnPuEb9NCHGVNjVKj6wZRJye/bJThXmPvVhcJ7xmMKQsABH/AJoejSUuvt+EKyB0rrlyyuQRt/ThPHqKHy8q1jE7kuC4Mt0EMe4KKQlRzjnmrW1SVKlNJWTt3DIz780KMy0JWG1KSDgE89KKNO2yZcO8koZW6hv+J86IsJUd6v1diTR8yhc8EjNR7hAjimeZodMenXPlGQ4qOSR3mCmXItQkL+XYcLefCSalV76nYZQ2/DW2VJCwlSxnB/2qV3imo9WkJDmnOOKVUxtxRWW8zyg5QCOCCT64rI/xf/CnO1gZHab2cQwq7toK7jb2xj5oAf5iB/PHUef1rSN17UbJAj7mY5W+tGWkKUMKV/Hg8feuH/HLSLKA29GmsykpDi2VsKIUnz2LHhJ+pFYU8/IVRky76rjXmOYi/IifpTwmZZshWnIjgY+Qip78OS5CnNOR5DKihxtxJSpKh1BB5BrvZk7ENuLI2PZ28+hwa3Z2udlnYn20aah3OXAXH1g5lMm5QFBgpPq4FDDnBHln3rNavhL1I1qCTZFasZbZZjBcJ9UNwJkKPRKiM7CfXmlrPUZLH2m1hQPDXwhr0vE5esl5BSRyy7jC6hSVw3VI3FCiMHyOKvoWo1G7xpylBTidiFE+3Q0w758N13kphO2y5Nh5mMy08FJViU6BhbiVnPOfLFCc74ce1OLdVQW0wQlBG55bxSgHqQDjnA9KH3aUXSSRBfL4jl20jPnaLfWd/bOuI12dUgiRCZCiOmQMUeM6vhwUWO2od4dK31859hQ7K+HXWTs2Gwu/wpi2mQHllpTaGuMgbycKP0rnc7I9QqlJefvrBVAUGEJYClY885x086HX8LOPIbaI+EW8iBBJL41lWFOOJV8Rvv4gmHVZtYwe/efelBDbCcpUVDBxXY9rKBHbacckZU4Svk8nPlS0u3ZHfIVmjhjVMWRMdkpwEtrwQemMeY9+K/iuytdjuMV+9avdkrwUKQ4NqO+zwE4wAPc1ijo/UVAuKAHD+ovPdJEuQerQVHjp6w4LXcmp7f4hdnmINpUNzsuQsJSoD9qM/qP0o4lds2ktM2CHMsfztzbRMSy+uIkHu2MZKl5wAT0+tJZ5iYbIjSjSIVzElxQTI/WmMSOEhI/dngiqXT+pZNgkNW65NoYU+y/EMcMFvcpQ6kHqcjj3pjYYp0vhho9jH3ihYqOtuAG4Zd++FdimrTOKnQZqwbRokepO8+m6LbUPb5f73e5s+Tp+8ttqdKYyEsL8LIGEg4PJ6n71K9IWm9S3OMiS8+qQoZTvekqbXgE4Ckn9JA8qlbqqi+tRUpVz9YH00+WSkAWEE1yionwJapKlK7pXAB254HpXhpy5P3DSaFS0NLLh2Hw44C8D/wCNSpUTiiDYGK6ADFJd9U3ezaujW+Gtn5RAbZ7hTSSlQIAJPmT96JNQ60vjUafMZcabcj7UNbEbQlKiBjAPT086lSp0pBCbxGSQTaFTJ1vqOw3SO+xOEg70upEhAUlBUk5AAxxTGsF3f1dqtNqvDEdTEba6ju0bSV4B3E55NSpXsxkRbhH0ybg/WLOyTVykxGZbTT5duzrS3FglRQDgDrjoPSiLUlmt9gdVGtLIYD2SVp/WnnyP3881KlUVE9bb6xdQPu7wB3qW9GS40Fd44JCG0vOcuAD36E/UGv3em03lu3/iJU6pTQdUvO0qVyOccVKlSDMR6km9o9rFYm7THhuQrhMQqU+04TvT+WdxB2eHw586MovZhpTWQci39mS+klZCkvFC05c3HChzyalSqUx9hwbOUSIzQbwV3Ls30lZHGbbbreptlllKR+YSpRGRuUTySfWpUqVECY+Y/9k=';
     }

--- a/tests/Feature/User/ProfileTest.php
+++ b/tests/Feature/User/ProfileTest.php
@@ -322,7 +322,8 @@ class ProfileTest extends JwtTestCase
      *
      * @return \Illuminate\Foundation\Testing\TestResponse
      */
-    private function jsonRequestFromGuest(string $type = 'get') {
+    private function jsonRequestFromGuest(string $type = 'get')
+    {
         return $this->json($this->routes[$type][0], $this->routes[$type][1]);
     }
 

--- a/tests/Feature/User/ProfileTest.php
+++ b/tests/Feature/User/ProfileTest.php
@@ -7,7 +7,6 @@ use App\Models\Trip;
 use Tests\JwtTestCase;
 use App\Models\Booking;
 use App\Models\Vehicle;
-use Illuminate\Support\Facades\Artisan;
 
 class ProfileTest extends JwtTestCase
 {
@@ -45,7 +44,6 @@ class ProfileTest extends JwtTestCase
     public function setUp()
     {
         parent::setUp();
-        Artisan::call('migrate:refresh');
 
         $this->routes['get'][] = route('user.profile.show');
         $this->routes['update'][] = route('user.profile.update');
@@ -56,7 +54,7 @@ class ProfileTest extends JwtTestCase
      */
     public function guest_can_not_show_profile()
     {
-        $response = $this->json($this->routes['get'][0], $this->routes['get'][1]);
+        $response = $this->jsonRequestFromGuest();
         $response->assertStatus(400);
     }
 
@@ -65,7 +63,7 @@ class ProfileTest extends JwtTestCase
      */
     public function guest_can_not_update_profile()
     {
-        $response = $this->json($this->routes['update'][0], $this->routes['update'][1]);
+        $response = $this->jsonRequestFromGuest('update');
         $response->assertStatus(400);
     }
 
@@ -74,9 +72,9 @@ class ProfileTest extends JwtTestCase
      */
     public function driver_can_show_profile()
     {
-        $user = $this->createDriver();
+        $user = $this->createDriver($this->driverData);
 
-        $response = $this->jsonRequestAsUser($user, $this->routes['get'][0], $this->routes['get'][1]);
+        $response = $this->jsonRequestUserProfile($user);
 
         $response->assertStatus(200)
              ->assertExactJson(['data' => $this->driverData + [
@@ -94,9 +92,9 @@ class ProfileTest extends JwtTestCase
      */
     public function passenger_can_show_profile()
     {
-        $user = $this->createPassenger();
+        $user = $this->createPassenger($this->passengerData);
 
-        $response = $this->jsonRequestAsUser($user, $this->routes['get'][0], $this->routes['get'][1]);
+        $response = $this->jsonRequestUserProfile($user);
 
         $response->assertStatus(200)
              ->assertExactJson(['data' => $this->passengerData + [
@@ -117,7 +115,7 @@ class ProfileTest extends JwtTestCase
             'permissions' => User::DRIVER_PERMISSION + User::PASSENGER_PERMISSION,
         ]);
 
-        $response = $this->jsonRequestAsUser($user, $this->routes['get'][0], $this->routes['get'][1]);
+        $response = $this->jsonRequestUserProfile($user);
 
         $response->assertStatus(200)
              ->assertJson(['data' => [
@@ -135,10 +133,10 @@ class ProfileTest extends JwtTestCase
             'permissions' => User::DRIVER_PERMISSION + User::PASSENGER_PERMISSION,
         ]);
 
-        $this->createVehicle($user->id);
-        $this->createTrip($user->id);
+        $this->createVehicle($user);
+        $this->createTrip($user);
 
-        $response = $this->jsonRequestAsUser($user, $this->routes['get'][0], $this->routes['get'][1]);
+        $response = $this->jsonRequestUserProfile($user);
 
         $response->assertStatus(200)
              ->assertJson(['data' => [
@@ -154,7 +152,7 @@ class ProfileTest extends JwtTestCase
     {
         $user = $this->createPassenger();
 
-        $response = $this->jsonRequestAsUser($user, $this->routes['get'][0], $this->routes['get'][1]);
+        $response = $this->jsonRequestUserProfile($user);
 
         $response->assertStatus(200)
              ->assertJson(['data' => [
@@ -171,11 +169,11 @@ class ProfileTest extends JwtTestCase
         $user = $this->createPassenger();
         $driver = $this->createDriver();
 
-        $this->createVehicle($driver->id);
-        $this->createTrip($driver->id);
-        $this->createBooking($user->id);
+        $this->createVehicle($driver);
+        $this->createTrip($driver);
+        $this->createBooking($user);
 
-        $response = $this->jsonRequestAsUser($user, $this->routes['get'][0], $this->routes['get'][1]);
+        $response = $this->jsonRequestUserProfile($user);
 
         $response->assertStatus(200)
              ->assertJson(['data' => [
@@ -194,44 +192,58 @@ class ProfileTest extends JwtTestCase
             'email' => 'is_exists@example.com',
         ]);
 
-        $response = $this->jsonUpdateUser($user, []);
+        $response = $this->jsonRequestUserProfile($user, 'update', []);
         $response->assertStatus(422);
 
         // Error - the first_name is required
-        $response = $this->jsonUpdateUser($user, ['first_name' => null]);
+        $response = $this->jsonRequestUserProfile($user, 'update', [
+            'first_name' => null,
+        ]);
         $response->assertStatus(422)->assertJsonStructure(['first_name' => []]);
 
         // Error - the last_name is required
-        $response = $this->jsonUpdateUser($user, ['last_name' => null]);
+        $response = $this->jsonRequestUserProfile($user, 'update', [
+            'last_name' => null,
+        ]);
         $response->assertStatus(422)->assertJsonStructure(['last_name' => []]);
 
         // Error - the email is required
-        $response = $this->jsonUpdateUser($user, ['email' => null]);
+        $response = $this->jsonRequestUserProfile($user, 'update', ['email' => null]);
         $response->assertStatus(422)->assertJsonStructure(['email' => []]);
 
         // Error - the email is exactly email
-        $response = $this->jsonUpdateUser($user, ['email' => 'Lorem ipsum dolor.']);
+        $response = $this->jsonRequestUserProfile($user, 'update', [
+            'email' => 'Lorem ipsum dolor.',
+        ]);
         $response->assertStatus(422)->assertJsonStructure(['email' => []]);
 
         // Error - the email is unique
-        $response = $this->jsonUpdateUser($user, ['email' => $userWithExistingEmail->email]);
+        $response = $this->jsonRequestUserProfile($user, 'update', [
+            'email' => $userWithExistingEmail->email,
+        ]);
         $response->assertStatus(422)->assertJsonStructure(['email' => []]);
 
         // Error - the phone is required
-        $response = $this->jsonUpdateUser($user, ['phone' => null]);
+        $response = $this->jsonRequestUserProfile($user, 'update', ['phone' => null]);
         $response->assertStatus(422)->assertJsonStructure(['phone' => []]);
 
         // Error - the phone has the valid format
-        $response = $this->jsonUpdateUser($user, ['phone' => 'dds1234567']);
+        $response = $this->jsonRequestUserProfile($user, 'update', [
+            'phone' => 'dds1234567',
+        ]);
         $response->assertStatus(422)->assertJsonStructure(['phone' => []]);
 
         // Error - the birth_date has the valid format
-        $response = $this->jsonUpdateUser($user, ['birth_date' => '1984 dfdf 08 -13']);
+        $response = $this->jsonRequestUserProfile($user, 'update', [
+            'birth_date' => '1984 dfdf 08 -13',
+        ]);
         $response->assertStatus(422)->assertJsonStructure(['birth_date' => []]);
 
         // Error - the about_me size is longer
         // than the maximum allowed number of characters
-        $response = $this->jsonUpdateUser($user, ['about_me' => str_random(505)]);
+        $response = $this->jsonRequestUserProfile($user, 'update', [
+            'about_me' => str_random(505),
+        ]);
         $response->assertStatus(422)->assertJsonStructure(['about_me' => []]);
     }
 
@@ -244,10 +256,12 @@ class ProfileTest extends JwtTestCase
             'permissions' => User::DRIVER_PERMISSION + User::PASSENGER_PERMISSION,
         ]);
 
-        $this->createVehicle($user->id);
-        $this->createTrip($user->id);
+        $this->createVehicle($user);
+        $this->createTrip($user);
 
-        $response = $this->jsonUpdateUser($user, ['role_driver' => false]);
+        $response = $this->jsonRequestUserProfile($user, 'update', [
+            'role_driver' => false,
+        ]);
         $response->assertStatus(422)->assertJsonStructure(['role_driver' => []]);
     }
 
@@ -259,11 +273,13 @@ class ProfileTest extends JwtTestCase
         $user = $this->createPassenger();
         $driver = $this->createDriver();
 
-        $this->createVehicle($driver->id);
-        $this->createTrip($driver->id);
-        $this->createBooking($user->id);
+        $this->createVehicle($driver);
+        $this->createTrip($driver);
+        $this->createBooking($user);
 
-        $response = $this->jsonUpdateUser($user, ['role_passenger' => false]);
+        $response = $this->jsonRequestUserProfile($user, 'update', [
+            'role_passenger' => false,
+        ]);
         $response->assertStatus(422)->assertJsonStructure(['role_passenger' => []]);
     }
 
@@ -286,10 +302,10 @@ class ProfileTest extends JwtTestCase
         $user = $this->createDriver([
             'permissions' => User::DRIVER_PERMISSION + User::PASSENGER_PERMISSION,
         ]);
-        $this->createVehicle($user->id);
-        $this->createTrip($user->id);
+        $this->createVehicle($user);
+        $this->createTrip($user);
 
-        $response = $this->jsonUpdateUser($user, $updatedData);
+        $response = $this->jsonRequestUserProfile($user, 'update', $updatedData);
 
         $response->assertStatus(200)
              ->assertExactJson(['data' => $updatedData + [
@@ -300,19 +316,34 @@ class ProfileTest extends JwtTestCase
     }
 
     /**
-     * Send request on the user profile update.
+     * Send request to the user profile from the guest user.
+     *
+     * @param string $type
+     *
+     * @return \Illuminate\Foundation\Testing\TestResponse
+     */
+    private function jsonRequestFromGuest(string $type = 'get') {
+        return $this->json($this->routes[$type][0], $this->routes[$type][1]);
+    }
+
+    /**
+     * Send request to the user profile.
      *
      * @param \App\User $user
+     * @param string $type
      * @param array $updatedData
      *
      * @return \Illuminate\Foundation\Testing\TestResponse
      */
-    private function jsonUpdateUser(User $user, array $updatedData = [])
-    {
+    private function jsonRequestUserProfile(
+        User $user,
+        string $type = 'get',
+        array $updatedData = []
+    ) {
         return $this->jsonRequestAsUser(
             $user,
-            $this->routes['update'][0],
-            $this->routes['update'][1],
+            $this->routes[$type][0],
+            $this->routes[$type][1],
             $updatedData
         );
     }
@@ -321,64 +352,69 @@ class ProfileTest extends JwtTestCase
      * Create a new driver.
      *
      * @param  array $fields
+     *
      * @return \App\User
      */
     private function createDriver(array $fields = []): User
     {
         $fields['permissions'] = $fields['permissions'] ?? User::DRIVER_PERMISSION;
 
-        return factory(User::class)->create(array_merge($this->driverData, $fields));
+        return factory(User::class)->create($fields);
     }
 
     /**
      * Create a new passenger.
      *
      * @param  array $fields
+     *
      * @return \App\User
      */
     private function createPassenger(array $fields = []): User
     {
         $fields['permissions'] = $fields['permissions'] ?? User::PASSENGER_PERMISSION;
 
-        return factory(User::class)->create(array_merge($this->passengerData, $fields));
+        return factory(User::class)->create($fields);
     }
 
     /**
      * Create a new vehicle.
      *
-     * @param  int $userId
+     * @param \App\User $user
+     *
      * @return \App\Models\Vehicle
      */
-    private function createVehicle(int $userId): Vehicle
+    private function createVehicle(User $user): Vehicle
     {
         return factory(Vehicle::class)->create([
-            'user_id' => $userId,
+            'user_id' => $user->id,
         ]);
     }
 
     /**
      * Create a new trip.
      *
-     * @param  int $userId
+     * @param \App\User $user
+     *
      * @return \App\Models\Trip
      */
-    private function createTrip(int $userId): Trip
+    private function createTrip(User $user): Trip
     {
         return factory(Trip::class)->create([
-            'user_id' => $userId,
+            'user_id' => $user->id,
         ]);
     }
 
     /**
      * Create a new booking.
      *
-     * @param  int $userId
+     * @param \App\User $user
+     *
      * @return \App\Models\Booking
      */
-    private function createBooking(int $userId): Booking
+    private function createBooking(User $user): Booking
     {
         return factory(Booking::class)->create([
-            'user_id' => $userId,
+            'user_id' => $user->id,
         ]);
     }
 }


### PR DESCRIPTION
Updating a user avatar using an image file with a format such as _WebP_ leads to its incorrect display in different browsers. In particular, _WebP_ is understood **only** by _Webkit_ browsers.

**Changes:**

  1. Available the avatar mimetypes - `image/jpeg,image/png`.
  2. Avatar sizes - 150/150 for better displaying (on public profiles pages, where the avatar is bigger).
  3. Some code improvements - new constants in `User`, the passing of the `User` model (not id) as a parameter in the controllers etc.

P.S.: special thanks to @PetRichBlog 😊  for trying to update the user avatar using a WebP file. His actions determined this problem.