### PR TITLE
Fix getting the count of unread notifications after reload a page

### DIFF
--- a/resources/assets/js/app/App.js
+++ b/resources/assets/js/app/App.js
@@ -1,10 +1,15 @@
 import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 
 import Preloader from './components/Preloader';
 import MainHeader from './components/MainHeader';
 import Notifications from './components/Notifications';
 
 import AuthService from './services/AuthService';
+
+import { getCountUnread } from './services/NotificationService';
+import { setCountUnreadNotifications } from 'features/notifications/actions';
 
 import './bootstrap/bootstrap.scss';
 import './bootstrap/font-awesome.scss';
@@ -19,22 +24,55 @@ class App extends React.Component {
             isShowContent: false,
         }
 
+        this.onAuthSuccess = this.onAuthSuccess.bind(this);
+        this.onAuthError = this.onAuthError.bind(this);
         this.setShowContent = this.setShowContent.bind(this);
     }
 
     componentWillMount() {
-        if (AuthService.isAuthorized() || !AuthService.isSessionTokenValid()) {
+        if (AuthService.isAuthorized()) {
+            this.onAuthSuccess();
+            return;
+        }
+
+        if (!AuthService.isSessionTokenValid()) {
             this.setShowContent();
             return;
         }
 
-        AuthService.getSessionDataFromServer(this.setShowContent);
+        AuthService.getSessionDataFromServer(this.onAuthSuccess, this.onAuthError);
+    }
+
+    componentWillReceiveProps() {
+        if (AuthService.isAuthorized()) {
+            this.onAuthSuccess();
+            return;
+        }
+
+        if (!AuthService.isSessionTokenValid()) {
+            this.setShowContent();
+            return;
+        }
     }
 
     setShowContent() {
         this.setState({
             isShowContent: true,
         });
+    }
+
+    onAuthSuccess() {
+        const { setCountUnreadNotifications } = this.props;
+
+        this.setShowContent();
+
+        getCountUnread().then(response => {
+            setCountUnreadNotifications(response.data);
+        });
+    }
+
+    onAuthError() {
+        this.setShowContent();
     }
 
     renderComponent() {
@@ -56,4 +94,8 @@ class App extends React.Component {
     }
 }
 
-export default App;
+export default connect(
+    state => ({}),
+    dispatch =>
+        bindActionCreators({ setCountUnreadNotifications }, dispatch)
+)(App);

--- a/resources/assets/js/app/routes.js
+++ b/resources/assets/js/app/routes.js
@@ -34,9 +34,6 @@ import AuthService from './services/AuthService';
 import { RequireUser, RequireGuest } from './components/Auth';
 import { USER_ROLE_PASSENGER, USER_ROLE_DRIVER } from './services/UserService';
 
-import { getCountUnread } from './services/NotificationService';
-import { setCountUnreadNotifications } from 'features/notifications/actions';
-
 import LangeService from './services/LangService';
 import DataStorage from './helpers/DataStorage';
 
@@ -52,22 +49,7 @@ export default (store) => {
     LangeService.addTranslation(require('./lang/validate.locale.json'));
 
     return (
-        <Route path="/" component={ App } onChange={() => {
-            if (!AuthService.isAuthorized()) {
-                return;
-            }
-            getCountUnread().then(response => {
-                store.dispatch(setCountUnreadNotifications(response.data));
-            });
-
-        }} onEnter={() => {
-            if (!AuthService.isAuthorized()) {
-                return;
-            }
-            getCountUnread().then(response => {
-                store.dispatch(setCountUnreadNotifications(response.data));
-            });
-        }}>
+        <Route path="/" component={ App }>
 
             <Route path="elements" component={ Elements } />
 


### PR DESCRIPTION
[![trs](https://user-images.githubusercontent.com/12577743/30219063-9438ad58-94c3-11e7-8359-212ee6e46cea.png) Fix getting the count of unread notifications after reload a page](https://trello.com/c/yjHXmFQG)

After reload a page the application can not get the count of unread notifications.

**Solution:**
Move this logic (shown below) from `app/routes` to `App` component.
```
      getCountUnread().then(response => {
            setCountUnreadNotifications(response.data);
      });
```