### PR TITLE
Fix/incorrect display of user age on the search page

### DIFF
--- a/app/Transformers/Search/DriverTransformer.php
+++ b/app/Transformers/Search/DriverTransformer.php
@@ -3,7 +3,6 @@
 namespace App\Transformers\Search;
 
 use App\User;
-use Carbon\Carbon;
 use League\Fractal\TransformerAbstract;
 
 class DriverTransformer extends TransformerAbstract

--- a/app/Transformers/Search/DriverTransformer.php
+++ b/app/Transformers/Search/DriverTransformer.php
@@ -19,12 +19,9 @@ class DriverTransformer extends TransformerAbstract
 
         return [
             'full_name' => $user->first_name.' '.$user->last_name,
-            'age' => $birthDate
-                ? Carbon::now()->year - $birthDate->year
-                : null,
             'first_name' => $user->first_name,
             'last_name' => $user->last_name,
-            'birth_date' => $birthDate ? $user->birth_date->timestamp : null,
+            'birth_date' => $user->birth_date ? $user->birth_date->format('Y-m-d') : null,
             'photo' => $user->getAvatarUrl(),
         ];
     }

--- a/resources/assets/js/features/search/components/Result/TripItem.js
+++ b/resources/assets/js/features/search/components/Result/TripItem.js
@@ -24,6 +24,8 @@ class TripItem extends React.Component {
         const { trip, translate } = this.props,
             startedAt = this.formatStartAt();
 
+            console.log(trip.driver.data);
+
         return (
             <Link to={`/trip/${trip.id}`} className="search-trip-item">
                 <div className="row search-trip-item-block">
@@ -41,9 +43,9 @@ class TripItem extends React.Component {
                         </div>
 
                         <div className="search-trip-item__user-age">
-                            { translate('search_result.years' + LangService.getNumberForm(
-                                trip.driver.data.age
-                            ), { age: trip.driver.data.age }) }
+                            { translate('search_result.years1', {
+                                age: DateTimeHelper.getUserYearsOld(trip.driver.data.birth_date)
+                            }) }
                         </div>
                     </div>
 

--- a/resources/assets/js/features/search/components/Result/TripItem.js
+++ b/resources/assets/js/features/search/components/Result/TripItem.js
@@ -24,8 +24,6 @@ class TripItem extends React.Component {
         const { trip, translate } = this.props,
             startedAt = this.formatStartAt();
 
-            console.log(trip.driver.data);
-
         return (
             <Link to={`/trip/${trip.id}`} className="search-trip-item">
                 <div className="row search-trip-item-block">


### PR DESCRIPTION
[![trs](https://user-images.githubusercontent.com/12577743/30219063-9438ad58-94c3-11e7-8359-212ee6e46cea.png) BUG :: Incorrect display of user age on the search page](https://trello.com/c/mRsDkmxA)

For example, the user birth date is **1986-11-17**.
On the search page his age display as **31** (counting does not affect the month).
On another pages it display correctly - **30**.