### PR TITLE
Fix/hide some info on public profile pages

### DIFF
--- a/resources/assets/js/features/public-profiles/components/ProfileBasicInfo.js
+++ b/resources/assets/js/features/public-profiles/components/ProfileBasicInfo.js
@@ -24,7 +24,7 @@ class ProfileBasicInfo extends React.Component {
                     }</span>
                 </h4>
 
-                <strong>{ translate('public_profile.profile_experience') } </strong> {
+                {/*<strong>{ translate('public_profile.profile_experience') } </strong> {
                     translate('public_profile.profile_experienced') } <br/>
 
                 <strong>{ translate('public_profile.profile_preferences') } </strong>
@@ -43,7 +43,7 @@ class ProfileBasicInfo extends React.Component {
                         data-toggle="tooltip"
                         data-placement="top"
                         title={ translate('public_profile.profile_animals_not_allowed') } />
-                </span>
+                </span>*/}
                 <br/>
             </div>
         );

--- a/resources/assets/js/features/public-profiles/components/ProfileVerifications.js
+++ b/resources/assets/js/features/public-profiles/components/ProfileVerifications.js
@@ -31,9 +31,9 @@ class ProfileVerifications extends React.Component {
                     <strong>{ translate('public_profile.verifications.header') } </strong>
                 </p>
                 <div className="driver-car-block__verifications">
-                    { this.renderVerificationRule('phone_number', true) }
+                    { /*this.renderVerificationRule('phone_number', true)*/ }
                     { this.renderVerificationRule('email', email_is_verified) }
-                    { this.renderVerificationRule('agreement', true) }
+                    { /*this.renderVerificationRule('agreement', true)*/ }
                 </div>
             </div>
         );

--- a/resources/assets/js/features/public-profiles/styles/public-profile.scss
+++ b/resources/assets/js/features/public-profiles/styles/public-profile.scss
@@ -185,5 +185,5 @@
 /* Send message button styles */
 
 #write_msg_to_user .fa-envelope::before{
-  padding-right: 4px;
+  margin-right: 10px;
 }


### PR DESCRIPTION
[![trs](https://user-images.githubusercontent.com/12577743/30219063-9438ad58-94c3-11e7-8359-212ee6e46cea.png) Hide some information on public profile page](https://trello.com/c/IxhGkFB6)
 - Experience and My preferences
 - Verification rules: phone and agreement
 - Better margin right for icon on the sending msg button