### PR TITLE
Fix/responsive vehicles list table

### DIFF
--- a/resources/assets/js/app/styles/app.scss
+++ b/resources/assets/js/app/styles/app.scss
@@ -370,7 +370,7 @@ td.table-list-details__cell-for-action {
         vertical-align: middle;
     }
     &__image {
-        max-width: 80px;
+        width: 80px;
 
         svg {
             margin-top: .5rem;

--- a/resources/assets/js/app/styles/app.scss
+++ b/resources/assets/js/app/styles/app.scss
@@ -346,11 +346,9 @@ dt {
     }
 }
 
-td.table-list-details__cell-for-action {
-    width: 20px;
-}
-
 .table-list-details {
+    margin-bottom: 0;
+
     th,
     td {
         font-size: .95rem;
@@ -375,6 +373,14 @@ td.table-list-details__cell-for-action {
         svg {
             margin-top: .5rem;
         }
+    }
+
+    &--actions {
+      height: 100%;
+
+      td {
+        padding: .25rem;
+      }
     }
 }
 

--- a/resources/assets/js/features/car/components/Containers/VehiclesList.js
+++ b/resources/assets/js/features/car/components/Containers/VehiclesList.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { localize } from 'react-localize-redux';
 
-import VehicleItem from '../Elements/VehicleItem';
+import { VehicleItem, VehicleActions } from '../Elements';
 import { getVehicles, deleteVehicle } from 'features/car/actions';
 
 class VehiclesList extends React.Component {
@@ -20,38 +20,68 @@ class VehiclesList extends React.Component {
         this.props.deleteVehicle(id);
     }
 
+    renderVehiclesItems() {
+        const { vehicles } = this.props;
+
+        if (vehicles.length <= 0) {
+            return null;
+        }
+
+        return vehicles.map(vehicle =>
+            <VehicleItem key={ vehicle.id } vehicle={ vehicle } />
+        );
+    }
+
+    renderVehiclesActions() {
+        const { vehicles } = this.props;
+
+        if (vehicles.length <= 0) {
+            return null;
+        }
+
+        return vehicles.map(vehicle =>
+            <VehicleActions key={ vehicle.id }
+                vehicle={ vehicle }
+                onDeleteVehicle={this.onDeleteVehicle} />
+        );
+    }
+
     render() {
         const { translate, vehicles } = this.props;
 
-        const vehiclesView = (vehicles.length > 0)
-            ? vehicles.map(vehicle => {
-                return (
-                    <VehicleItem key={ vehicle.id } vehicle={ vehicle }
-                        onDeleteVehicle={this.onDeleteVehicle} />
-                );
-            })
-            : null;
-
         return (
-            <div className="table-responsive">
-                <table className="table table-list-details">
-                    <thead className="with-background-teal">
-                        <tr>
-                            <th>{ translate('vehicles_list.options.brand') }</th>
-                            <th>{ translate('vehicles_list.options.model') }</th>
-                            <th>{ translate('vehicles_list.options.year') }</th>
-                            <th>{ translate('vehicles_list.options.body') }</th>
-                            <th>{ translate('vehicles_list.options.color') }</th>
-                            <th>{ translate('vehicles_list.options.seats') }</th>
-                            <th>{ translate('vehicles_list.options.photo') }</th>
-                            <th className="table-details__cell-for-action"></th>
-                            <th className="table-details__cell-for-action"></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        { vehiclesView }
-                    </tbody>
-                </table>
+            <div className="d-flex justify-content-between">
+                <div className="table-responsive">
+                    <table className="table table-list-details">
+                        <thead className="with-background-teal">
+                            <tr>
+                                <th>{ translate('vehicles_list.options.brand') }</th>
+                                <th>{ translate('vehicles_list.options.model') }</th>
+                                <th>{ translate('vehicles_list.options.year') }</th>
+                                <th>{ translate('vehicles_list.options.body') }</th>
+                                <th>{ translate('vehicles_list.options.color') }</th>
+                                <th>{ translate('vehicles_list.options.seats') }</th>
+                                <th>{ translate('vehicles_list.options.photo') }</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {this.renderVehiclesItems()}
+                        </tbody>
+                    </table>
+                </div>
+                <div>
+                    <table className="table table-list-details">
+                        <thead className="with-background-teal">
+                            <tr>
+                                <th className="table-details__cell-for-action">&nbsp;</th>
+                                <th className="table-details__cell-for-action">&nbsp;</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {this.renderVehiclesActions()}
+                        </tbody>
+                    </table>
+                </div>
             </div>
         );
     }

--- a/resources/assets/js/features/car/components/Containers/VehiclesList.js
+++ b/resources/assets/js/features/car/components/Containers/VehiclesList.js
@@ -33,24 +33,26 @@ class VehiclesList extends React.Component {
             : null;
 
         return (
-            <table className="table table-list-details">
-                <thead className="with-background-teal">
-                    <tr>
-                        <th>{ translate('vehicles_list.options.brand') }</th>
-                        <th>{ translate('vehicles_list.options.model') }</th>
-                        <th>{ translate('vehicles_list.options.year') }</th>
-                        <th>{ translate('vehicles_list.options.body') }</th>
-                        <th>{ translate('vehicles_list.options.color') }</th>
-                        <th>{ translate('vehicles_list.options.seats') }</th>
-                        <th>{ translate('vehicles_list.options.photo') }</th>
-                        <th className="table-details__cell-for-action"></th>
-                        <th className="table-details__cell-for-action"></th>
-                    </tr>
-                </thead>
-                <tbody>
-                    { vehiclesView }
-                </tbody>
-            </table>
+            <div className="table-responsive">
+                <table className="table table-list-details">
+                    <thead className="with-background-teal">
+                        <tr>
+                            <th>{ translate('vehicles_list.options.brand') }</th>
+                            <th>{ translate('vehicles_list.options.model') }</th>
+                            <th>{ translate('vehicles_list.options.year') }</th>
+                            <th>{ translate('vehicles_list.options.body') }</th>
+                            <th>{ translate('vehicles_list.options.color') }</th>
+                            <th>{ translate('vehicles_list.options.seats') }</th>
+                            <th>{ translate('vehicles_list.options.photo') }</th>
+                            <th className="table-details__cell-for-action"></th>
+                            <th className="table-details__cell-for-action"></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        { vehiclesView }
+                    </tbody>
+                </table>
+            </div>
         );
     }
 }

--- a/resources/assets/js/features/car/components/Containers/VehiclesList.js
+++ b/resources/assets/js/features/car/components/Containers/VehiclesList.js
@@ -70,7 +70,7 @@ class VehiclesList extends React.Component {
                     </table>
                 </div>
                 <div>
-                    <table className="table table-list-details">
+                    <table className="table table-list-details table-list-details--actions">
                         <thead className="with-background-teal">
                             <tr>
                                 <th className="table-details__cell-for-action">&nbsp;</th>

--- a/resources/assets/js/features/car/components/Elements/VehicleActions.js
+++ b/resources/assets/js/features/car/components/Elements/VehicleActions.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { EditButton, DeleteButton } from 'app/components/Buttons';
+
+class VehicleActions extends React.Component {
+
+    render() {
+        const { vehicle, onDeleteVehicle } = this.props;
+
+        return (
+            <tr>
+                <td className="table-list-details__cell-for-action">
+                    <EditButton pathTo={'vehicles/edit/' + vehicle.id} />
+                </td>
+                <td className="table-list-details__cell-for-action">
+                    <DeleteButton onClick={() => onDeleteVehicle(vehicle.id)} />
+                </td>
+            </tr>
+        );
+    }
+}
+
+VehicleActions.propTypes = {
+    vehicle: PropTypes.object.isRequired,
+    onDeleteVehicle: PropTypes.func.isRequired,
+};
+
+export default VehicleActions;

--- a/resources/assets/js/features/car/components/Elements/VehicleItem.js
+++ b/resources/assets/js/features/car/components/Elements/VehicleItem.js
@@ -1,13 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { EditButton, DeleteButton } from 'app/components/Buttons';
 import { getVehiclePhoto } from 'app/services/PhotoService';
 
 class VehicleItem extends React.Component {
 
     render() {
-        const { vehicle, onDeleteVehicle } = this.props;
+        const { vehicle } = this.props;
 
         return (
             <tr>
@@ -22,12 +21,6 @@ class VehicleItem extends React.Component {
                         { getVehiclePhoto(vehicle) }
                     </div>
                 </td>
-                <td className="table-list-details__cell-for-action">
-                    <EditButton pathTo={ 'vehicles/edit/' + vehicle.id } />
-                </td>
-                <td className="table-list-details__cell-for-action">
-                    <DeleteButton onClick={() => onDeleteVehicle(vehicle.id)} />
-                </td>
             </tr>
         );
     }
@@ -35,7 +28,6 @@ class VehicleItem extends React.Component {
 
 VehicleItem.propTypes = {
     vehicle: PropTypes.object.isRequired,
-    onDeleteVehicle: PropTypes.func.isRequired,
 };
 
 export default VehicleItem;

--- a/resources/assets/js/features/car/components/Elements/index.js
+++ b/resources/assets/js/features/car/components/Elements/index.js
@@ -1,0 +1,7 @@
+import VehicleItem from './VehicleItem';
+import VehicleActions from './VehicleActions';
+
+export {
+    VehicleItem,
+    VehicleActions,
+};


### PR DESCRIPTION
[![trs](https://user-images.githubusercontent.com/12577743/30219063-9438ad58-94c3-11e7-8359-212ee6e46cea.png) Fix :: responsive vehicles list table](https://trello.com/c/udcCQw6W)

---

На скрине `:: BAD ::` видна **проблема**: на малом разрешении экрана хедер, футер, и др. элементы успешно ужимаются. Таблица - остается со своим размером. Выглядит некрасиво.

На след. скринах - **решение**. Я добавил `table-responsive` от _Bootstrap_. Таким образом, если разрешение экрана уменьшается, у таблицы появляется гориз. скролл. Пользователь сможет прокрутить пальцем в сторону и посмотреть данные.

Также я **отдельно вынес** область с кнопками _Редактирования/Удаления_. Т.е. она остается **всегда справа** от таблицы, которая скроллится.

Если пользователь захочет что-то изменить или удалить, то он **сразу же** нажмет нужную кнопку вместо того, чтобы скроллить до конца всю таблицу.

---

**:: BAD ::**
![bad](https://user-images.githubusercontent.com/12577743/30754757-abd8164c-9fcc-11e7-9273-21df59210dbb.JPG)

**:: GOOD ::**

**Big screen**

![main](https://user-images.githubusercontent.com/12577743/30754770-ba9ee142-9fcc-11e7-9a04-f6c2ce2eeb83.JPG)

**Smaller screen**

 Add **scrollbar** for table.
 Section with buttons _"Edit"_ and _"Delete"_ is **always in one place** (not scroll).

![better](https://user-images.githubusercontent.com/12577743/30754837-03acd2b8-9fcd-11e7-91d1-f5287863aadc.JPG)

![better2](https://user-images.githubusercontent.com/12577743/30754839-0651dde2-9fcd-11e7-9874-3ec542a60288.JPG)

